### PR TITLE
Use the (currently) unassigned port range 4380-4388 as the default ports for GEDS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ GEDS is a distributed epehemeral datastore that enables flexible scaling of comp
 - [Building](doc/BUILDING.md)
 - [geds_smart_open Python package](src/python/geds_smart_open/README.md)
 
+## Ports
+
+GEDS uses the following default ports (see also `src/utility/Ports.h`).
+- **Web / Prometheus**: 4380
+- **Metadata Server**: 4381
+- **GEDS RPC**: 4382
+
 ## Benchmarking
 
 1. Start the metadata server on `$HOST`:
@@ -14,7 +21,7 @@ GEDS is a distributed epehemeral datastore that enables flexible scaling of comp
 2. Start the benchmarking server on a separate node
    ```
    GEDS_METADATASERVER_HOST=$HOST
-   GEDS_METADATASERVER_PORT=50001
+   GEDS_METADATASERVER_PORT=4381
    export GEDS_METADATASERVER=${GEDS_METADATASERVER_HOST}:${GEDS_METADATASERVER_PORT}
    cd $GEDS_INSTALL/python
    python3.9 serve_benchmark.py
@@ -22,6 +29,6 @@ GEDS is a distributed epehemeral datastore that enables flexible scaling of comp
 3. Run the benchmark command:
    ```bash
    GEDS_METADATASERVER_HOST=$HOST
-   GEDS_METADATASERVER_PORT=50001
+   GEDS_METADATASERVER_PORT=4381
    $GEDS_INSTALL/bin/benchmark --serverAddress $GEDS_METADATASERVER_HOST --serverPort $GEDS_METADATASERVER_PORT --outputFile output.csv
    ```

--- a/docker/Dockerfile_debian11.5
+++ b/docker/Dockerfile_debian11.5
@@ -23,5 +23,6 @@ RUN apt-get clean && apt-get update \
 
 COPY --from=builder /usr/local/opt/geds/ /usr/local/
 
-EXPOSE 50001
-EXPOSE 50053
+EXPOSE 4380
+EXPOSE 4381
+EXPOSE 4382

--- a/docker/Dockerfile_ubuntu20.04
+++ b/docker/Dockerfile_ubuntu20.04
@@ -23,5 +23,6 @@ RUN apt-get clean && apt-get update \
 
 COPY --from=builder /usr/local/opt/geds/ /usr/local/
 
-EXPOSE 50001
-EXPOSE 50053
+EXPOSE 4380
+EXPOSE 4381
+EXPOSE 4382

--- a/docker/Dockerfile_ubuntu22.04
+++ b/docker/Dockerfile_ubuntu22.04
@@ -19,5 +19,6 @@ RUN apt-get clean && apt-get update \
 
 COPY --from=builder /usr/local/opt/geds/ /usr/local/
 
-EXPOSE 50001
-EXPOSE 50053
+EXPOSE 4380
+EXPOSE 4381
+EXPOSE 4382

--- a/kubernetes/metadata-server.yml
+++ b/kubernetes/metadata-server.yml
@@ -6,7 +6,7 @@ spec:
   selector:
     app: geds-metadataserver
   ports:
-  - port: 50001
+  - port: 4381
   selector:
     app: geds-metadataserver
 ---
@@ -23,7 +23,7 @@ spec:
     image: us.icr.io/zrlio/geds-dev:latest
     imagePullPolicy: Always
     ports:
-    - containerPort: 50001
+    - containerPort: 4381
     command: [ "/usr/local/bin/metadataserver" ]
     resources:
       requests:

--- a/kubernetes/python-create.yml
+++ b/kubernetes/python-create.yml
@@ -9,9 +9,9 @@ spec:
     command: [ "python3.9", "/usr/local/python/create.py"  ]
     imagePullPolicy: Always
     ports:
-    - containerPort: 50003
+    - containerPort: 4382
     env:
     - name: GEDS_METADATASERVER
-      value: geds-metadataserver:50001
+      value: geds-metadataserver:4381
   imagePullSecrets:
     - name: zrlio

--- a/kubernetes/python-read.yml
+++ b/kubernetes/python-read.yml
@@ -9,9 +9,9 @@ spec:
     command: [ "python3.9", "/usr/local/python/read.py"  ]
     imagePullPolicy: Always
     ports:
-    - containerPort: 50003
+    - containerPort: 4382
     env:
     - name: GEDS_METADATASERVER
-      value: geds-metadataserver:50001
+      value: geds-metadataserver:4381
   imagePullSecrets:
     - name: zrlio

--- a/src/python/geds_smart_open/README.md
+++ b/src/python/geds_smart_open/README.md
@@ -3,7 +3,7 @@
 ## Environment variables
 
 GEDS can be configured using the following environment variables:
-- `GEDS_METADATASERVER`: GEDS Metadata Server, default: `geds-metadataserver:50001`.
+- `GEDS_METADATASERVER`: GEDS Metadata Server, default: `geds-metadataserver:4381`.
 - `GEDS_TMP`: GEDS Folder for ephemeral data, default: `/tmp/GEDS_XXXXXX`.
 - `GEDS_BLOCK_SIZE`: GEDS Block size in bytes (optional).
 

--- a/src/utility/Ports.h
+++ b/src/utility/Ports.h
@@ -8,8 +8,8 @@
 
 #include <cstdint>
 
-const uint16_t defaultMetdataServerPort = 50001;
-const uint16_t defaultGEDSPort = 50002;
-const uint16_t defaultPrometheusPort = 10223;
+const uint16_t defaultPrometheusPort = 4380;
+const uint16_t defaultMetdataServerPort = 4381;
+const uint16_t defaultGEDSPort = 4382;
 
 #endif


### PR DESCRIPTION
See here:
https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt

Signed-off-by: Pascal Spörri <psp@zurich.ibm.com>