### PR TITLE
Improve handling of Object Stores

### DIFF
--- a/src/libgeds/GEDS.cpp
+++ b/src/libgeds/GEDS.cpp
@@ -271,6 +271,11 @@ absl::Status GEDS::mkdirs(const std::string &bucket, const std::string &path, ch
     LOG_ERROR("Unable to create folder ", folderPath);
     return mkdir.status();
   }
+  auto status = mkdir->seal();
+  if (!status.ok() && status.code() != absl::StatusCode::kAlreadyExists) {
+    LOG_ERROR("Unable to seal directory marker: ", path, " reason: ", status.message());
+    return status;
+  }
   if (path.size() >= 2) {
     auto stripPos = path.substr(0, path.size() - 1).rfind(delimiter);
     if (stripPos == std::string::npos) {
@@ -340,24 +345,6 @@ GEDS::openAsFileHandle(const std::string &bucket, const std::string &key, bool i
   // File is not available locally. Lookup in metadata service instead.
   auto status_file = _metadataService.lookup(bucket, key, invalidate);
   if (!status_file.ok()) {
-    // The file is not registered.
-    // Try open file on s3:
-    auto s3FileHandle = GEDSCachedFileHandle::factory<GEDSS3FileHandle>(shared_from_this(), bucket,
-                                                                        key, std::nullopt);
-    if (s3FileHandle.ok()) {
-      // Use file handle registered with fileHandles object.
-      auto eexists = _fileHandles.insertOrExists(path, *s3FileHandle);
-      if (s3FileHandle->get() == eexists.get()) {
-        // Seal filehandle to avoid extranous lookups.
-        (void)eexists->seal();
-      }
-      return eexists;
-    }
-    // The file does not exist.
-    // Otherwise return not found from metadata service.
-    if (s3FileHandle.status().code() != absl::StatusCode::kNotFound) {
-      return s3FileHandle.status();
-    }
     return status_file.status();
   }
 
@@ -471,16 +458,6 @@ absl::StatusOr<std::vector<GEDSFileStatus>> GEDS::list(const std::string &bucket
   }
   for (const auto &prefix : list->second) {
     result.emplace(GEDSFileStatus{.key = prefix, .size = 0, .isDirectory = true});
-  }
-  auto extStatus = _objectStores.get(bucket);
-  if (extStatus.ok()) {
-    auto ext = extStatus.value();
-    auto s3status = ext->list(bucket, prefix, delimiter, result);
-    if (s3status.ok()) {
-      prefixExists = true;
-    } else {
-      return s3status;
-    }
   }
   if (result.empty() && delimiter && !prefixExists) {
     return absl::NotFoundError("Prefix not found: " + prefix);

--- a/src/libgeds/GEDS.h
+++ b/src/libgeds/GEDS.h
@@ -87,7 +87,7 @@ protected:
    */
   utility::ConcurrentMap<utility::Path, std::shared_ptr<GEDSFileHandle>, std::less<>> _fileHandles;
   inline utility::Path getPath(const std::string &bucket, const std::string &key) {
-    return {bucket + "/" + key};
+    return {bucket + key};
   }
   utility::ConcurrentMap<std::string, std::shared_ptr<geds::FileTransferService>> _fileTransfers;
 
@@ -152,10 +152,10 @@ public:
    * @brief Create object located at bucket/key.
    * The object is registered with the metadata service once the file is sealed.
    */
-  absl::StatusOr<GEDSFile> create(const std::string &bucket, const std::string &key,
+  absl::StatusOr<GEDSFile> create(const std::string &bucket, std::string key,
                                   bool overwrite = false);
   absl::StatusOr<std::shared_ptr<GEDSFileHandle>>
-  createAsFileHandle(const std::string &bucket, const std::string &key, bool overwrite = false);
+  createAsFileHandle(const std::string &bucket, std::string key, bool overwrite = false);
 
   /**
    * @brief Recursively create directory using directory markers.
@@ -173,9 +173,9 @@ public:
   /**
    * @brief Open object located at bucket/key.
    */
-  absl::StatusOr<GEDSFile> open(const std::string &bucket, const std::string &key);
+  absl::StatusOr<GEDSFile> open(const std::string &bucket, std::string key);
   absl::StatusOr<std::shared_ptr<GEDSFileHandle>>
-  openAsFileHandle(const std::string &bucket, const std::string &key, bool invalidate = false);
+  openAsFileHandle(const std::string &bucket, std::string key, bool invalidate = false);
 
   /**
    * @brief Mark the file associated with fileHandle as sealed.
@@ -197,8 +197,8 @@ public:
    * separator. Keys ending with "/_$folder$" will be used as directory markers (where '/' is used
    * as a delimiter).
    */
-  absl::StatusOr<std::vector<GEDSFileStatus>> list(const std::string &bucket,
-                                                   const std::string &prefix, char delimiter);
+  absl::StatusOr<std::vector<GEDSFileStatus>> list(const std::string &bucket, std::string prefix,
+                                                   char delimiter);
 
   /**
    * @brief List objects in `bucket` with `/` acting as delimiter.
@@ -210,32 +210,31 @@ public:
    * @brief Get status of `key` in `bucket`.
    */
   absl::StatusOr<GEDSFileStatus> status(const std::string &bucket, const std::string &key);
-  absl::StatusOr<GEDSFileStatus> status(const std::string &bucket, const std::string &key,
-                                        char delimiter);
+  absl::StatusOr<GEDSFileStatus> status(const std::string &bucket, std::string key, char delimiter);
 
   /**
    * @brief Rename a prefix recursively.
    */
   absl::Status renamePrefix(const std::string &bucket, const std::string &srcPrefix,
                             const std::string &destPrefix);
-  absl::Status renamePrefix(const std::string &srcBucket, const std::string &srcPrefix,
-                            const std::string &destPrefix, const std::string &destKey);
+  absl::Status renamePrefix(const std::string &srcBucket, std::string srcPrefix,
+                            const std::string &destPrefix, std::string destKey);
 
   /**
    * @brief Rename an object.
    */
   absl::Status rename(const std::string &bucket, const std::string &srcKey,
                       const std::string &destKey);
-  absl::Status rename(const std::string &srcBucket, const std::string &srcKey,
-                      const std::string &destBucket, const std::string &destKey);
+  absl::Status rename(const std::string &srcBucket, std::string srcKey,
+                      const std::string &destBucket, std::string destKey);
 
   /**
    * @brief Copy a file or a folder structure.
    */
   absl::Status copyPrefix(const std::string &bucket, const std::string &srcPrefix,
                           const std::string &destPrefix);
-  absl::Status copyPrefix(const std::string &srcBucket, const std::string &srcPrefix,
-                          const std::string &destPrefix, const std::string &destKey);
+  absl::Status copyPrefix(const std::string &srcBucket, std::string srcPrefix,
+                          const std::string &destPrefix, std::string destKey);
 
   /**
    * @brief Copy an object.
@@ -249,13 +248,13 @@ public:
    * @brief Delete object in `bucket` with `key`.
    * @returns absl::OkStatus if the operation has been successful or not objects have been deleted.
    */
-  absl::Status deleteObject(const std::string &bucket, const std::string &key);
+  absl::Status deleteObject(const std::string &bucket, std::string key);
 
   /**
    * @brief Delete objects in `bucket` with keys starting with `prefix`.
    * @returns absl::OkStatus if the operation has been successful or not objects have been deleted.
    */
-  absl::Status deleteObjectPrefix(const std::string &bucket, const std::string &prefix);
+  absl::Status deleteObjectPrefix(const std::string &bucket, std::string prefix);
 
   /**
    * @brief Compute the path to the files stored in `_pathPrefix` folder.

--- a/src/metadataservice/CMakeLists.txt
+++ b/src/metadataservice/CMakeLists.txt
@@ -8,6 +8,8 @@ set(SOURCES
         GRPCServer.h
         ObjectStoreHandler.cpp
         ObjectStoreHandler.h
+        S3Helper.cpp
+        S3Helper.h
 )
 
 add_library(libmetadataservice STATIC ${SOURCES})
@@ -16,6 +18,7 @@ target_link_libraries(libmetadataservice
         ${GRPC_LIBRARIES}
         geds_utility
         geds_proto
+        geds_s3
 )
 target_compile_options(libmetadataservice PUBLIC ${GEDS_EXTRA_COMPILER_FLAGS})
 target_compile_definitions(libmetadataservice

--- a/src/metadataservice/GRPCServer.cpp
+++ b/src/metadataservice/GRPCServer.cpp
@@ -23,6 +23,7 @@
 #include "ObjectStoreConfig.h"
 #include "ObjectStoreHandler.h"
 #include "ParseGRPC.h"
+#include "S3Helper.h"
 #include "Status.h"
 #include "Version.h"
 
@@ -74,8 +75,12 @@ protected:
     LOG_ACCESS("register object store ", request->endpointurl(), " for bucket ", request->bucket(),
                "'.");
 
-    auto status = _objectStoreHandler.insertConfig(std::make_shared<geds::ObjectStoreConfig>(
-        request->bucket(), request->endpointurl(), request->accesskey(), request->secretkey()));
+    auto config = std::make_shared<geds::ObjectStoreConfig>(
+        request->bucket(), request->endpointurl(), request->accesskey(), request->secretkey());
+    auto status = _objectStoreHandler.insertConfig(config);
+    if (status.ok()) {
+      status = PopulateKVS(config, _kvs);
+    }
     convertStatus(response, status);
 
     return grpc::Status::OK;

--- a/src/metadataservice/S3Helper.cpp
+++ b/src/metadataservice/S3Helper.cpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2023- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "S3Helper.h"
+
+#include <map>
+
+#include "Logging.h"
+#include "Object.h"
+#include "S3Endpoint.h"
+
+absl::Status PopulateKVS(std::shared_ptr<geds::ObjectStoreConfig> config,
+                         std::shared_ptr<KVS> kvs) {
+  // Ensure the bucket already exists
+  {
+    auto status = kvs->createBucket(config->bucket);
+    if (!status.ok() && status.code() != absl::StatusCode::kAlreadyExists) {
+      return status;
+    }
+  }
+  auto bucket = kvs->getBucket(config->bucket);
+  if (!bucket.ok()) {
+    return bucket.status();
+  }
+  auto s3Endpoint = geds::s3::Endpoint(config->endpointURL, config->accessKey, config->secretKey);
+  auto files = s3Endpoint.list(config->bucket, "");
+  if (!files.ok()) {
+    LOG_ERROR("Unable to list s3 endpoint for ", config->bucket, ": ", files.status().message());
+    return files.status();
+  }
+  for (const auto &f : *files) {
+    if (f.isDirectory) {
+      continue;
+    }
+    LOG_DEBUG("Adding: ", config->bucket, "/", f.key);
+    auto objInfo = geds::ObjectInfo{
+        .location = "s3://" + config->bucket + "/" + f.key,
+        .size = f.size,
+        .sealedOffset = f.size,
+    };
+    auto status = (*bucket)->createObject(
+        geds::Object{.id = geds::ObjectID{config->bucket, f.key}, .info = objInfo});
+    if (!status.ok() && status.code() != absl::StatusCode::kAlreadyExists) {
+      LOG_ERROR("Unable to create entry for ", config->bucket, "/", f.key, ": ", status.message());
+      continue;
+    }
+  }
+  return absl::OkStatus();
+}

--- a/src/metadataservice/S3Helper.h
+++ b/src/metadataservice/S3Helper.h
@@ -1,0 +1,12 @@
+/**
+ * Copyright 2023- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "KVS.h"
+#include "ObjectStoreConfig.h"
+#include "ObjectStoreHandler.h"
+
+absl::Status PopulateKVS(std::shared_ptr<geds::ObjectStoreConfig> config, std::shared_ptr<KVS> kvs);

--- a/src/metadataservice/S3Helper.h
+++ b/src/metadataservice/S3Helper.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "KVS.h"
+#include "MDSKVS.h"
 #include "ObjectStoreConfig.h"
 #include "ObjectStoreHandler.h"
 
-absl::Status PopulateKVS(std::shared_ptr<geds::ObjectStoreConfig> config, std::shared_ptr<KVS> kvs);
+absl::Status PopulateKVS(std::shared_ptr<geds::ObjectStoreConfig> config, std::shared_ptr<MDSKVS> kvs);

--- a/src/utility/MDSKVS.h
+++ b/src/utility/MDSKVS.h
@@ -22,13 +22,6 @@ class MDSKVS : public utility::RWConcurrentObjectAdaptor {
 private:
   std::map<std::string, std::shared_ptr<MDSKVSBucket>> _map;
 
-  std::shared_lock<std::shared_mutex> getReadLock() {
-    return std::shared_lock<std::shared_mutex>(_mutex);
-  }
-
-  std::unique_lock<std::shared_mutex> getWriteLock() {
-    return std::unique_lock<std::shared_mutex>(_mutex);
-  }
 public:
   MDSKVS();
 
@@ -92,11 +85,9 @@ public:
    */
   absl::StatusOr<std::pair<std::vector<geds::Object>, std::vector<std::string>>>
   listObjects(const geds::ObjectID &id, char delimiter = 0);
+  absl::StatusOr<std::pair<std::vector<geds::Object>, std::vector<std::string>>>
+  listObjects(const std::string &bucket, const std::string &prefix, char delimiter = 0);
 
   absl::StatusOr<std::shared_ptr<MDSKVSBucket>> getBucket(const std::string &bucket);
   absl::StatusOr<std::shared_ptr<MDSKVSBucket>> getBucket(const geds::ObjectID &id);
-};
-
-  absl::StatusOr<std::pair<std::vector<geds::Object>, std::vector<std::string>>>
-  listObjects(const std::string &bucket, const std::string &prefix, char delimiter = 0);
 };

--- a/src/utility/MDSKVS.h
+++ b/src/utility/MDSKVS.h
@@ -22,9 +22,13 @@ class MDSKVS : public utility::RWConcurrentObjectAdaptor {
 private:
   std::map<std::string, std::shared_ptr<MDSKVSBucket>> _map;
 
-  absl::StatusOr<std::shared_ptr<MDSKVSBucket>> getBucket(const std::string &bucket);
-  absl::StatusOr<std::shared_ptr<MDSKVSBucket>> getBucket(const geds::ObjectID &id);
+  std::shared_lock<std::shared_mutex> getReadLock() {
+    return std::shared_lock<std::shared_mutex>(_mutex);
+  }
 
+  std::unique_lock<std::shared_mutex> getWriteLock() {
+    return std::unique_lock<std::shared_mutex>(_mutex);
+  }
 public:
   MDSKVS();
 
@@ -88,6 +92,10 @@ public:
    */
   absl::StatusOr<std::pair<std::vector<geds::Object>, std::vector<std::string>>>
   listObjects(const geds::ObjectID &id, char delimiter = 0);
+
+  absl::StatusOr<std::shared_ptr<MDSKVSBucket>> getBucket(const std::string &bucket);
+  absl::StatusOr<std::shared_ptr<MDSKVSBucket>> getBucket(const geds::ObjectID &id);
+};
 
   absl::StatusOr<std::pair<std::vector<geds::Object>, std::vector<std::string>>>
   listObjects(const std::string &bucket, const std::string &prefix, char delimiter = 0);


### PR DESCRIPTION
- Avoid extra lookups to S3 by deferring the initial lookup to the Metadata server.
- Make prefix handling consistent: Always remove first `/` to emulate S3 API.