### PR TITLE
Add operator= to StatisticsGauge, integrate LocalStorageSize and LocalMemorySize.

### DIFF
--- a/src/libgeds/GEDSAbstractFileHandle.h
+++ b/src/libgeds/GEDSAbstractFileHandle.h
@@ -81,6 +81,8 @@ public:
   }
 
   absl::StatusOr<size_t> size() const override { return _file.size(); }
+  size_t localStorageSize() const override { return _file.localStorageSize(); }
+  size_t localMemorySize() const override { return _file.localMemorySize(); }
   virtual size_t sealedSize() const { return _sealedSize; }
   bool isWriteable() const override { return true; }
 

--- a/src/libgeds/GEDSCachedFileHandle.cpp
+++ b/src/libgeds/GEDSCachedFileHandle.cpp
@@ -43,6 +43,31 @@ GEDSCachedFileHandle::GEDSCachedFileHandle(std::shared_ptr<GEDS> gedsService, st
 
 absl::StatusOr<size_t> GEDSCachedFileHandle::size() const { return _remoteSize; }
 
+size_t GEDSCachedFileHandle::localStorageSize() const {
+  size_t result = 0;
+  for (size_t idx = 0; idx < _blocks.size(); idx++) {
+    auto lock = std::lock_guard(_blockMutex[idx]);
+    if (_blocks[idx].get() == nullptr) {
+      continue;
+    }
+    auto fh = _blocks[idx]->fileHandle();
+    result += fh->localStorageSize();
+  }
+  return result;
+}
+
+size_t GEDSCachedFileHandle::localMemorySize() const {
+  size_t result = 0;
+  for (size_t idx = 0; idx < _blocks.size(); idx++) {
+    auto lock = std::lock_guard(_blockMutex[idx]);
+    if (_blocks[idx].get() == nullptr) {
+      continue;
+    }
+    auto fh = _blocks[idx]->fileHandle();
+    result += fh->localMemorySize();
+  }
+  return result;
+}
 absl::StatusOr<size_t> GEDSCachedFileHandle::readBytes(uint8_t *bytes, size_t position,
                                                        size_t length) {
 

--- a/src/libgeds/GEDSCachedFileHandle.h
+++ b/src/libgeds/GEDSCachedFileHandle.h
@@ -27,7 +27,7 @@ class GEDSCachedFileHandle : public GEDSFileHandle {
   size_t _blockSize;
 
   std::vector<std::shared_ptr<GEDSFile>> _blocks;
-  std::vector<std::mutex> _blockMutex;
+  mutable std::vector<std::mutex> _blockMutex;
 
   std::shared_ptr<geds::StatisticsCounter> _readStatistics =
       geds::Statistics::createCounter("GEDSCachedFileHandle: bytes read");
@@ -75,6 +75,8 @@ public:
   GEDSCachedFileHandle &operator=(GEDSCachedFileHandle &&) = delete;
 
   absl::StatusOr<size_t> size() const override;
+  size_t localStorageSize() const override;
+  size_t localMemorySize() const override;
 
   absl::StatusOr<size_t> readBytes(uint8_t *bytes, size_t position, size_t length) override;
 

--- a/src/libgeds/GEDSFileHandle.h
+++ b/src/libgeds/GEDSFileHandle.h
@@ -55,6 +55,9 @@ public:
   virtual ~GEDSFileHandle();
 
   virtual absl::StatusOr<size_t> size() const = 0;
+  virtual size_t localStorageSize() const { return 0; }
+  virtual size_t localMemorySize() const { return 0; }
+
   int64_t openCount() const;
   void increaseOpenCount();
   void decreaseOpenCount();

--- a/src/libgeds/LocalFile.h
+++ b/src/libgeds/LocalFile.h
@@ -50,6 +50,8 @@ public:
   void notifyUnused();
 
   [[nodiscard]] size_t size() const { return _size; }
+  [[nodiscard]] size_t localStorageSize() const { return _size; }
+  [[nodiscard]] size_t localMemorySize() const { return 0; }
 
   absl::StatusOr<int> rawFd() const;
 

--- a/src/libgeds/MMAPFile.h
+++ b/src/libgeds/MMAPFile.h
@@ -51,7 +51,8 @@ public:
   [[nodiscard]] const std::string &path() const { return _path; }
 
   [[nodiscard]] size_t size() const { return _size; }
-
+  [[nodiscard]] size_t localStorageSize() const { return _size; }
+  [[nodiscard]] size_t localMemorySize() const { return _mmapSize; }
   absl::StatusOr<uint8_t *> rawPtr();
 
   absl::StatusOr<int> rawFd() const;

--- a/src/statistics/StatisticsGauge.cpp
+++ b/src/statistics/StatisticsGauge.cpp
@@ -17,6 +17,11 @@ void StatisticsGauge::printForConsole(std::stringstream &stream) const {
   stream << label << ", " << _value << std::endl;
 }
 
+StatisticsGauge &StatisticsGauge::operator=(size_t v) {
+  _value = v;
+  return *this;
+}
+
 StatisticsGauge &StatisticsGauge::operator+=(size_t v) {
   _value += v;
   return *this;

--- a/src/statistics/StatisticsGauge.h
+++ b/src/statistics/StatisticsGauge.h
@@ -25,6 +25,7 @@ public:
   void printForPrometheus(std::stringstream &stream) const override;
   void printForConsole(std::stringstream &stream) const override;
 
+  StatisticsGauge &operator=(size_t v);
   StatisticsGauge &operator+=(size_t v) override;
   StatisticsGauge &operator-=(size_t v) override;
 


### PR DESCRIPTION
- Implement = operator for StatisticsGauge
- Implement LocalStorageSize and LocalMemorySize to determine localstorage/local memory used by GEDS.
Extracted from https://github.com/IBM/GEDS/pull/42/files