### PR TITLE
Fix Off-by-One in S3, return error code on TcpTransport and add fsync to LocalFile.

### DIFF
--- a/src/libgeds/LocalFile.cpp
+++ b/src/libgeds/LocalFile.cpp
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <fcntl.h>
 #include <ios>
 #include <stdexcept>
@@ -65,6 +66,20 @@ LocalFile::~LocalFile() {
 
 void LocalFile::notifyUnused() {
   // NOOP.
+}
+
+absl::Status LocalFile::fsync() {
+  CHECK_FILE_OPEN
+
+  int e = 0;
+  do {
+    e = ::fsync(_fd);
+  } while (e != 0 && errno == EINTR);
+  if (e != 0) {
+    int err = errno;
+    return absl::UnknownError("Unable to fsync " + _path + ": " + strerror(err));
+  }
+  return absl::OkStatus();
 }
 
 absl::StatusOr<size_t> LocalFile::fileSize() const {

--- a/src/libgeds/LocalFile.h
+++ b/src/libgeds/LocalFile.h
@@ -49,6 +49,8 @@ public:
 
   void notifyUnused();
 
+  absl::Status fsync();
+
   [[nodiscard]] size_t size() const { return _size; }
   [[nodiscard]] size_t localStorageSize() const { return _size; }
   [[nodiscard]] size_t localMemorySize() const { return 0; }

--- a/src/libgeds/MetadataService.cpp
+++ b/src/libgeds/MetadataService.cpp
@@ -312,6 +312,7 @@ absl::StatusOr<geds::Object> MetadataService::lookup(const std::string &bucket,
   METADATASERVICE_CHECK_CONNECTED;
 
   if (!invalidate) {
+    LOG_DEBUG("Lookup cache", bucket, "/", key);
     auto c = _mdsCache.lookup(bucket, key);
     if (c.ok()) {
       return c;
@@ -324,6 +325,8 @@ absl::StatusOr<geds::Object> MetadataService::lookup(const std::string &bucket,
 
   geds::rpc::ObjectResponse response;
   grpc::ClientContext context;
+
+  LOG_DEBUG("Lookup remote", bucket, "/", key);
 
   auto status = _stub->Lookup(&context, request, &response);
   if (!status.ok()) {

--- a/src/s3/S3Endpoint.h
+++ b/src/s3/S3Endpoint.h
@@ -82,7 +82,7 @@ public:
 
   absl::Status putObject(const std::string &bucket, const std::string &key,
                          std::shared_ptr<std::iostream> stream,
-                         std::optional<size_t> length = std::nullopt);
+                         std::optional<size_t> length = std::nullopt) const;
 
   absl::StatusOr<size_t> readBytes(const std::string &bucket, const std::string &key,
                                    uint8_t *bytes, size_t position, size_t length) const;


### PR DESCRIPTION
- S3: Fix the range request when reading from S3. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
- TcpTransport: Add missing error code to reply.
- GEDS Metadata Service: Add additional logs to debug caching issues.
- LocalFile: Integrate fsync to enable reading the data from a separate thread or process (required for spilling).