### PR TITLE
Object relocation and TcpTransport fixes, additional counters to measure local storage.

### DIFF
--- a/src/libgeds/FileTransferService.h
+++ b/src/libgeds/FileTransferService.h
@@ -26,6 +26,7 @@
 #include "FileTransferProtocol.h"
 #include "GEDSInternal.h"
 #include "Object.h"
+#include "RWConcurrentObjectAdaptor.h"
 #include "TcpTransport.h"
 #include "geds.grpc.pb.h"
 
@@ -38,13 +39,13 @@ struct RemoteFileInfo {
   const size_t length;
 };
 
-class FileTransferService {
+class FileTransferService: public utility::RWConcurrentObjectAdaptor {
   ConnectionState _connectionState;
   std::shared_ptr<grpc::Channel> _channel;
   std::unique_ptr<geds::rpc::GEDSService::Stub> _stub;
   std::shared_ptr<GEDS> _geds;
   std::shared_ptr<TcpTransport> _tcp;
-  std::shared_ptr<TcpPeer> tcpPeer;
+  std::weak_ptr<TcpPeer> _tcpPeer;
 
   absl::StatusOr<std::vector<std::tuple<sockaddr, geds::FileTransferProtocol>>>
   availTransportEndpoints();

--- a/src/libgeds/GEDS.cpp
+++ b/src/libgeds/GEDS.cpp
@@ -367,6 +367,7 @@ absl::StatusOr<GEDSFile> GEDS::localOpen(const std::string &bucket, const std::s
   if (fileHandle.has_value() && (*fileHandle)->rawFd().ok()) {
     // The filehandle has an FD, and is thus local.
     // TODO: FIXME.
+    auto lock = (*fileHandle)->lockFile();
     return (*fileHandle)->open();
   }
   return absl::NotFoundError(path.name + " is not available on this machine");

--- a/src/libgeds/GEDS.h
+++ b/src/libgeds/GEDS.h
@@ -184,7 +184,9 @@ public:
   absl::StatusOr<GEDSFile> open(const std::string &bucket, const std::string &key,
                                 bool retry = true);
   absl::StatusOr<std::shared_ptr<GEDSFileHandle>>
-  openAsFileHandle(const std::string &bucket, const std::string &key, bool invalidate = false);
+  openAsFileHandle(const std::string &bucket, const std::string &key);
+  absl::StatusOr<std::shared_ptr<GEDSFileHandle>>
+  reopenFileHandle(const std::string &bucket, const std::string &key, bool invalidate);
 
   /**
    * @brief Reopen a file after a unsuccessful read.

--- a/src/libgeds/GEDS.h
+++ b/src/libgeds/GEDS.h
@@ -107,6 +107,9 @@ protected:
   std::thread _storageMonitoringThread;
   void startStorageMonitoringThread();
 
+  std::atomic<size_t> _localStorageUsed;
+  std::atomic<size_t> _localMemoryUsed;
+
 public:
   /**
    * @brief GEDS CTOR. Note: This CTOR needs to be wrapped in a SHARED_POINTER!
@@ -304,6 +307,13 @@ public:
   void relocate(bool force = false);
   void relocate(std::vector<std::shared_ptr<GEDSFileHandle>> &relocatable, bool force = false);
   void relocate(std::shared_ptr<GEDSFileHandle> handle, bool force = false);
+
+  size_t localStorageUsed() const;
+  size_t localStorageFree() const;
+  size_t localStorageAllocated() const;
+  size_t localMemoryUsed() const;
+  size_t localMemoryFree() const;
+  size_t localMemoryAllocated() const;
 };
 
 #endif // GEDS_GEDS_H

--- a/src/libgeds/GEDSAbstractFileHandle.h
+++ b/src/libgeds/GEDSAbstractFileHandle.h
@@ -135,8 +135,8 @@ public:
   }
 
   absl::Status seal() override {
-    auto ioLock = lockExclusive();
     auto lock = lockFile();
+    auto ioLock = lockExclusive();
     size_t currentSize = _file.size();
     absl::Status status = absl::OkStatus();
     // FIXME: Create a GEDS Service mock to skip this abonimation below here.
@@ -150,8 +150,8 @@ public:
   }
 
   void notifyUnused() override {
-    auto iolock = lockExclusive();
     auto lock = lockFile();
+    auto iolock = lockExclusive();
     if (_openCount > 0) {
       return;
     }
@@ -164,8 +164,8 @@ public:
   }
 
   absl::StatusOr<std::shared_ptr<GEDSFileHandle>> relocate() override {
-    auto iolock = lockExclusive();
     auto lock = lockFile();
+    auto iolock = lockExclusive();
     if (!isValid()) {
       return absl::UnavailableError("The file " + identifier + " is no longer valid!");
     }

--- a/src/libgeds/GEDSFile.cpp
+++ b/src/libgeds/GEDSFile.cpp
@@ -64,19 +64,8 @@ const std::shared_ptr<GEDSFileHandle> GEDSFile::fileHandle() const { return _fil
 
 bool GEDSFile::isWriteable() const { return _fileHandle->isWriteable(); }
 
-absl::StatusOr<size_t> GEDSFile::readBytes(uint8_t *bytes, size_t position, size_t length,
-                                           bool retry) {
-  auto status = _fileHandle->readBytes(bytes, position, length);
-  if (status.ok() || !retry) {
-    return status;
-  }
-  auto fh = _geds->reopen(_fileHandle);
-  // Unable to reopen: Return error.
-  if (!fh.ok()) {
-    return fh.status();
-  }
-  _fileHandle = *fh;
-  return readBytes(bytes, position, length, false);
+absl::StatusOr<size_t> GEDSFile::readBytes(uint8_t *bytes, size_t position, size_t length) {
+  return _fileHandle->readBytes(bytes, position, length);
 }
 
 absl::Status GEDSFile::writeBytes(const uint8_t *bytes, size_t position, size_t length) {

--- a/src/libgeds/GEDSFile.h
+++ b/src/libgeds/GEDSFile.h
@@ -32,8 +32,7 @@ protected:
   std::shared_ptr<GEDS> _geds;
   std::shared_ptr<GEDSFileHandle> _fileHandle;
 
-  absl::StatusOr<size_t> readBytes(uint8_t *bytes, size_t position, size_t length,
-                                   bool retry = true);
+  absl::StatusOr<size_t> readBytes(uint8_t *bytes, size_t position, size_t length);
   absl::Status writeBytes(const uint8_t *bytes, size_t position, size_t length);
 
 public:

--- a/src/libgeds/GEDSRelocatableFileHandle.cpp
+++ b/src/libgeds/GEDSRelocatableFileHandle.cpp
@@ -96,8 +96,8 @@ absl::Status GEDSRelocatableFileHandle::seal() {
 }
 
 void GEDSRelocatableFileHandle::notifyUnused() {
-  auto lockIo = lockExclusive();
   auto lock = lockFile();
+  auto lockIo = lockExclusive();
   return _fileHandle->notifyUnused();
 };
 
@@ -107,8 +107,8 @@ absl::StatusOr<int> GEDSRelocatableFileHandle::rawFd() const {
 }
 
 absl::StatusOr<std::shared_ptr<GEDSFileHandle>> GEDSRelocatableFileHandle::relocate() {
-  auto lockIo = lockExclusive();
   auto lock = lockFile();
+  auto lockIo = lockExclusive();
 
   auto newFh = _fileHandle->relocate();
   if (newFh.ok()) {

--- a/src/libgeds/TcpTransport.cpp
+++ b/src/libgeds/TcpTransport.cpp
@@ -164,6 +164,11 @@ bool TcpPeer::SocketTxReady(int sock) {
  */
 bool TcpPeer::processEndpointSend(std::shared_ptr<TcpEndpoint> tep) {
   struct TcpSendState *ctx = &tep->send_ctx;
+  if (ctx->state == PROC_FAILED) {
+    LOG_ERROR("TcpPeer: Context is in failed state! Aborting!");
+    return false;
+  }
+
   int sock = tep->sock;
 
   ssize_t sent = 0;

--- a/src/libgeds/TcpTransport.h
+++ b/src/libgeds/TcpTransport.h
@@ -98,6 +98,7 @@ struct TcpRcvState {
   uint64_t va;
   std::string objName;
   size_t progress;
+
   std::shared_ptr<std::promise<absl::StatusOr<size_t>>> p;
 };
 


### PR DESCRIPTION
- Fixes stackoverflow when a filehandle is relocated.
- Fixes livelock when a peer crashes