### PR TITLE
Metadata Server: ObjectStoreHandler fix insertion into object store.

### DIFF
--- a/src/metadataservice/ObjectStoreHandler.cpp
+++ b/src/metadataservice/ObjectStoreHandler.cpp
@@ -12,11 +12,12 @@ ObjectStoreHandler::insertConfig(std::shared_ptr<const geds::ObjectStoreConfig> 
   auto lock = getWriteLock();
   auto key = config->bucket;
   auto [it, success] = _map.insert(std::make_pair(key, config));
-  if (!success && *(it->second) != *config) {
+  if (!success) {
     return absl::AlreadyExistsError("ObjectStore config for bucket already exists: '" + key + "'.");
   }
   return absl::OkStatus();
 }
+
 std::vector<std::shared_ptr<const geds::ObjectStoreConfig>>
 ObjectStoreHandler::listConfigs() const {
   auto lock = getReadLock();


### PR DESCRIPTION
Avoids querying the object store multiple times.