### PR TITLE
GEDS: Fix object relocation error.

### DIFF
--- a/src/libgeds/TcpTransport.cpp
+++ b/src/libgeds/TcpTransport.cpp
@@ -570,7 +570,7 @@ bool TcpPeer::processEndpointRecv(int sock) {
           auto message = "Error from GET_REPLY: " + std::to_string(ctx->hdr.error) +
                          "length: " + std::to_string(datalen) + " Ep: " + std::to_string(tep->sock);
           LOG_DEBUG(message);
-          ctx->p->set_value(absl::AbortedError(message));
+          ctx->p->set_value(absl::UnknownError(message));
           ctx->p = nullptr;
           ctx->state = PROC_IDLE;
           ctx->progress = 0;


### PR DESCRIPTION
Aborted indicates that there is an error on the transport: https://github.com/IBM/GEDS/blob/8b204055f23a089e3751b56ba052ceb8c53d9e5f/src/libgeds/FileTransferService.cpp#L161-L164