### PR TITLE
Port fixes from experiments.

### DIFF
--- a/src/libgeds/GEDS.cpp
+++ b/src/libgeds/GEDS.cpp
@@ -894,8 +894,12 @@ void GEDS::relocate(std::vector<std::shared_ptr<GEDSFileHandle>> &relocatable, b
         std::lock_guard lock(h->mutex);
         h->nTasks -= 1;
       }
-      h->cv.notify_one();
+      h->cv.notify_all();
     });
+
+    const auto tp_size = _config.io_thread_pool_size;
+    std::unique_lock lock(h->mutex);
+    h->cv.wait(lock, [h, tp_size]() { return h->nTasks <= (tp_size + 1); });
   }
   std::unique_lock lock(h->mutex);
   h->cv.wait(lock, [h]() { return h->nTasks == 0; });
@@ -912,19 +916,27 @@ void GEDS::relocate(std::shared_ptr<GEDSFileHandle> handle, bool force) {
   }
 
   static auto stats = geds::Statistics::createCounter("GEDS: Storage Relocated");
+  auto fsize = handle->localStorageSize();
   *stats += handle->localStorageSize();
 
   // Remove cached files.
   const auto path = getPath(handle->bucket, handle->key);
   if (handle->key.starts_with(GEDSCachedFileHandle::CacheBlockMarker)) {
-    _fileHandles.removeIf(path, [handle](const std::shared_ptr<GEDSFileHandle> &existing) {
-      return handle.get() == existing.get();
-    });
+    auto status =
+        _fileHandles.removeIf(path, [handle](const std::shared_ptr<GEDSFileHandle> &existing) {
+          return handle.get() == existing.get();
+        });
+    if (status) {
+      *stats += fsize;
+    }
     return;
   }
 
   // Relocate all other files.
-  (void)handle->relocate();
+  auto status = handle->relocate();
+  if (status.ok()) {
+    *stats += fsize;
+  }
 }
 
 void GEDS::startStorageMonitoringThread() {

--- a/src/libgeds/GEDS.cpp
+++ b/src/libgeds/GEDS.cpp
@@ -496,7 +496,11 @@ GEDS::reopenFileHandle(const std::string &bucket, const std::string &key, bool i
   if (location.compare(0, gedsPrefix.size(), gedsPrefix) == 0) {
     fileHandle = GEDSRemoteFileHandle::factory(shared_from_this(), object);
   } else if (location.compare(0, s3Prefix.size(), s3Prefix) == 0) {
-    fileHandle = GEDSCachedFileHandle::factory<GEDSS3FileHandle>(shared_from_this(), object);
+    if (_config.cache_objects_from_s3) {
+      fileHandle = GEDSCachedFileHandle::factory<GEDSS3FileHandle>(shared_from_this(), object);
+    } else {
+      fileHandle = GEDSS3FileHandle::factory(shared_from_this(), object);
+    }
   } else {
     return absl::UnknownError("The remote location format " + location + " is not known.");
   }

--- a/src/libgeds/GEDS.cpp
+++ b/src/libgeds/GEDS.cpp
@@ -947,7 +947,7 @@ void GEDS::startStorageMonitoringThread() {
           auto memSize = fh->localMemorySize();
           storageUsed += storageSize;
           memoryUsed += memSize;
-          if (fh->isRelocatable() && memoryUsed == 0) {
+          if (fh->isRelocatable() && fh->openCount() == 0) {
             relocatable.push_back(fh);
           }
         }
@@ -970,26 +970,18 @@ void GEDS::startStorageMonitoringThread() {
         *statsLocalMemoryFree = _memoryCounters.free;
       }
 
-      auto targetStorage = (size_t)(0.5 * (double)_config.available_local_storage);
+      auto targetStorage =
+          (size_t)(_config.storage_spilling_fraction * (double)_config.available_local_storage);
       if (storageUsed > targetStorage) {
         std::sort(std::begin(relocatable), std::end(relocatable),
                   [](std::shared_ptr<GEDSFileHandle> a, std::shared_ptr<GEDSFileHandle> b) {
-                    if (a->openCount() == 0 && b->openCount() == 0) {
-                      return a->lastReleased() < b->lastReleased();
-                    }
-                    if (a->openCount() == 0) {
-                      return true;
-                    }
-                    if (b->openCount() == 0) {
-                      return false;
-                    }
-                    return a->lastOpened() < b->lastOpened();
+                    return a->lastReleased() < b->lastReleased();
                   });
 
         std::vector<std::shared_ptr<GEDSFileHandle>> tasks;
         size_t relocateBytes = 0;
         for (auto &f : relocatable) {
-          if (relocateBytes > targetStorage) {
+          if (relocateBytes > (storageUsed - targetStorage)) {
             break;
           }
           relocateBytes += f->localStorageSize();

--- a/src/libgeds/GEDS.cpp
+++ b/src/libgeds/GEDS.cpp
@@ -177,7 +177,9 @@ absl::Status GEDS::stop() {
 
   geds::Statistics::print();
   // Relocate to S3 if available.
-  relocate(true);
+  if (_config.force_relocation_when_stopping) {
+    relocate(true);
+  }
 
   auto result = _metadataService.disconnect();
   if (!result.ok()) {

--- a/src/libgeds/GEDSAbstractFileHandle.h
+++ b/src/libgeds/GEDSAbstractFileHandle.h
@@ -211,7 +211,7 @@ public:
     }
     auto status = (*fh)->seal();
     if (!status.ok()) {
-      LOG_ERROR("Unable to seal relocated file!");
+      LOG_ERROR("Unable to seal relocated file: ", status.message());
       (void)(*s3Endpoint)->deleteObject(bucket, key);
       return status;
     }

--- a/src/libgeds/GEDSConfig.cpp
+++ b/src/libgeds/GEDSConfig.cpp
@@ -55,6 +55,8 @@ absl::Status GEDSConfig::set(const std::string &key, size_t value) {
     pubSubEnabled = value != 0;
   } else if (key == "cache_objects_from_s3") {
     cache_objects_from_s3 = value != 0;
+  } else if (key == "force_relocation_when_stopping") {
+    force_relocation_when_stopping = value != 0;
   } else {
     LOG_ERROR("Configuration " + key + " not supported (type: signed/unsigned integer).");
     return absl::NotFoundError("Key " + key + " not found.");

--- a/src/libgeds/GEDSConfig.cpp
+++ b/src/libgeds/GEDSConfig.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "GEDSConfig.h"
+
 #include "Logging.h"
 
 absl::Status GEDSConfig::set(const std::string &key, const std::string &value) {
@@ -68,6 +69,15 @@ absl::Status GEDSConfig::set(const std::string &key, int64_t value) {
   return set(key, (size_t)value);
 }
 
+absl::Status GEDSConfig::set(const std::string &key, double value) {
+  if (key == "storage_spilling_fraction") {
+    storage_spilling_fraction = value;
+    return absl::OkStatus();
+  }
+  LOG_ERROR("Configuration " + key + " not supported (type: double).");
+  return absl::NotFoundError("Key " + key + " not found.");
+}
+
 absl::StatusOr<std::string> GEDSConfig::getString(const std::string &key) const {
   LOG_INFO("Get ", key, " as string");
   if (key == "listen_address") {
@@ -113,4 +123,12 @@ absl::StatusOr<int64_t> GEDSConfig::getSignedInt(const std::string &key) const {
     return (int64_t)*value;
   }
   return value.status();
+}
+
+absl::StatusOr<double> GEDSConfig::getDouble(const std::string &key) const {
+  if (key == "storage_spilling_fraction") {
+    return storage_spilling_fraction;
+  }
+  LOG_ERROR("Configuration " + key + " not supported (type: double).");
+  return absl::NotFoundError("Key " + key + " (double) not found.");
 }

--- a/src/libgeds/GEDSConfig.cpp
+++ b/src/libgeds/GEDSConfig.cpp
@@ -53,6 +53,8 @@ absl::Status GEDSConfig::set(const std::string &key, size_t value) {
     available_local_memory = value;
   } else if (key == "pub_sub_enabled") {
     pubSubEnabled = value != 0;
+  } else if (key == "cache_objects_from_s3") {
+    cache_objects_from_s3 = value != 0;
   } else {
     LOG_ERROR("Configuration " + key + " not supported (type: signed/unsigned integer).");
     return absl::NotFoundError("Key " + key + " not found.");

--- a/src/libgeds/GEDSConfig.h
+++ b/src/libgeds/GEDSConfig.h
@@ -16,7 +16,6 @@
 
 #include "Ports.h"
 
-
 struct GEDSConfig {
   /**
    * @brief The hostname of the metadata service/
@@ -84,6 +83,11 @@ struct GEDSConfig {
    * @brief Publish/Subscribe is enabled.
    */
   bool pubSubEnabled = false;
+
+  /**
+   * @brief Cache objects located in S3.
+   */
+  bool cache_objects_from_s3 = false;
 
   /**
    * @brief Fraction of the storage where GEDS should start spilling.

--- a/src/libgeds/GEDSConfig.h
+++ b/src/libgeds/GEDSConfig.h
@@ -63,11 +63,6 @@ struct GEDSConfig {
   size_t cacheBlockSize = 32 * 1024 * 1024;
 
   /**
-   * @brief Relocate files on GEDS::close.
-   */
-  bool relocate_on_close = false;
-
-  /**
    * @brief Size of I/O thread pool.
    */
   size_t io_thread_pool_size = std::max(std::thread::hardware_concurrency() / 2, (uint32_t)8);
@@ -88,6 +83,11 @@ struct GEDSConfig {
    * @brief Cache objects located in S3.
    */
   bool cache_objects_from_s3 = false;
+
+  /**
+   * @brief Force relocation when stopping.
+   */
+  bool force_relocation_when_stopping = false;
 
   /**
    * @brief Fraction of the storage where GEDS should start spilling.

--- a/src/libgeds/GEDSConfig.h
+++ b/src/libgeds/GEDSConfig.h
@@ -95,7 +95,12 @@ struct GEDSConfig {
   double storage_spilling_fraction = 0.7;
 
   GEDSConfig(std::string metadataServiceAddressArg)
-      : metadataServiceAddress(std::move(metadataServiceAddressArg)) {}
+      : metadataServiceAddress(std::move(metadataServiceAddressArg)) {
+    if (available_local_storage <= 4 * 1024 * 1024 * (size_t)1024) {
+      io_thread_pool_size = std::min<size_t>(io_thread_pool_size, 6);
+      storage_spilling_fraction = 0.9;
+    }
+  }
 
   absl::Status set(const std::string &key, const std::string &value);
   absl::Status set(const std::string &key, size_t value);

--- a/src/libgeds/GEDSConfig.h
+++ b/src/libgeds/GEDSConfig.h
@@ -16,6 +16,7 @@
 
 #include "Ports.h"
 
+
 struct GEDSConfig {
   /**
    * @brief The hostname of the metadata service/
@@ -84,14 +85,21 @@ struct GEDSConfig {
    */
   bool pubSubEnabled = false;
 
+  /**
+   * @brief Fraction of the storage where GEDS should start spilling.
+   */
+  double storage_spilling_fraction = 0.7;
+
   GEDSConfig(std::string metadataServiceAddressArg)
       : metadataServiceAddress(std::move(metadataServiceAddressArg)) {}
 
   absl::Status set(const std::string &key, const std::string &value);
   absl::Status set(const std::string &key, size_t value);
   absl::Status set(const std::string &key, int64_t value);
+  absl::Status set(const std::string &key, double value);
 
   absl::StatusOr<std::string> getString(const std::string &key) const;
   absl::StatusOr<size_t> getUnsignedInt(const std::string &key) const;
   absl::StatusOr<int64_t> getSignedInt(const std::string &key) const;
+  absl::StatusOr<double> getDouble(const std::string &key) const;
 };

--- a/src/libgeds/TcpTransport.cpp
+++ b/src/libgeds/TcpTransport.cpp
@@ -311,7 +311,7 @@ void TcpTransport::tcpTxThread(unsigned int id) {
   }
   epoll_wfd[id] = poll_fd;
   do {
-    int cnt = ::epoll_wait(poll_fd, events, EPOLL_MAXEVENTS, -1);
+    int cnt = ::epoll_wait(poll_fd, events, EPOLL_MAXEVENTS, 500);
 
     for (int i = 0; i < cnt; i++) {
       struct epoll_event *ev = &events[i];
@@ -657,7 +657,7 @@ void TcpTransport::tcpRxThread(unsigned int id) {
   epoll_rfd[id] = poll_fd;
 
   do {
-    int cnt = ::epoll_wait(poll_fd, events, EPOLL_MAXEVENTS, -1);
+    int cnt = ::epoll_wait(poll_fd, events, EPOLL_MAXEVENTS, 500);
 
     for (int i = 0; i < cnt; i++) {
       struct epoll_event *ev = &events[i];

--- a/src/python/create.py
+++ b/src/python/create.py
@@ -36,11 +36,12 @@ message_read = bytearray(len(message))
 l = file.read(message_read, 0, len(message_read))
 print(f"Read: {message_read.decode()}")
 
-# Print path
-# print(f"File: {file.path()}")
+file.seal()
+
+file2 = instance.create("bucket2", "testfile2")
+file2.write(message_read, 0, len(message))
+file2.seal()
 
 # Seal file
-
-file.seal()
 
 sleep(1000000)

--- a/src/utility/MDSKVSBucket.cpp
+++ b/src/utility/MDSKVSBucket.cpp
@@ -104,3 +104,13 @@ MDSKVSBucket::listObjects(const std::string &keyPrefix, char delimiter) {
   return std::make_pair(std::move(result),
                         std::vector<std::string>{commonPrefixes.begin(), commonPrefixes.end()});
 }
+
+void MDSKVSBucket::forall(
+    std::function<void(const utility::Path &, const geds::ObjectInfo &)> action) const {
+  auto lock = getReadLock();
+  for (const auto &v : _map) {
+    const auto &key = v.first;
+    const auto &value = v.second;
+    action(key, value->obj);
+  }
+}

--- a/src/utility/MDSKVSBucket.h
+++ b/src/utility/MDSKVSBucket.h
@@ -52,4 +52,6 @@ public:
   absl::StatusOr<geds::Object> lookup(const std::string &key);
   absl::StatusOr<std::pair<std::vector<geds::Object>, std::vector<std::string>>>
   listObjects(const std::string &keyPrefix, char delimiter = 0);
+
+  void forall(std::function<void(const utility::Path &, const geds::ObjectInfo &)> action) const;
 };


### PR DESCRIPTION
- Support storage spilling fraction
- Improve MDSKVS
- Enable configuration of S3 caching
- Properly count relocated storage
- Extend simple python example
- Workaround to fix Spark shutdown.