### PR TITLE
Bump java version to 1.2

### DIFF
--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -22,7 +22,7 @@ SET(SOURCES
         Platform.cpp
 )
 
-set(GEDS_JAVA_VERSION 1.1)
+set(GEDS_JAVA_VERSION 1.2)
 
 set(GEDS_JAR_GROUPID "com.ibm.geds")
 set(CMAKE_JAR_ARTIFACT_NAME "geds")


### PR DESCRIPTION
Ensure that GEDS-HDFS is able to correctly link against Metadata Support.