### PR TITLE
Fix TCP transport

### DIFF
--- a/src/libgeds/FileTransferService.cpp
+++ b/src/libgeds/FileTransferService.cpp
@@ -155,6 +155,7 @@ absl::StatusOr<size_t> FileTransferService::readBytes(const std::string &bucket,
   }
   auto status = fut.get();
   if (status.ok()) {
+    LOG_DEBUG("TCP readBytes OK, bytes: ", length);
     return *status;
   }
   // Close the FileTransferService on error.

--- a/src/libgeds/TcpTransport.cpp
+++ b/src/libgeds/TcpTransport.cpp
@@ -673,7 +673,6 @@ void TcpTransport::tcpRxThread(unsigned int id) {
       }
       auto it = tcpPeers.get(epId);
       if (it.has_value()) {
-        LOG_DEBUG("Found peer for %d: ", sock);
         tcpPeer = *it;
       } else {
         LOG_ERROR("No peer for: ", sock);

--- a/src/libgeds/TcpTransport.h
+++ b/src/libgeds/TcpTransport.h
@@ -218,6 +218,9 @@ private:
   int epoll_rfd[MAX_IO_THREADS] = {}; // for epoll() receive
   int epoll_wfd[MAX_IO_THREADS] = {}; // for epoll() send
 
+  /* fd to signal threads in epoll to interrupt wait */
+  int eventFd = -1;
+
   void deactivateEndpoint(int poll_fd, int sock, uint32_t state);
   bool activateEndpoint(std::shared_ptr<TcpEndpoint>, std::shared_ptr<TcpPeer>);
   utility::ConcurrentMap<unsigned int, std::shared_ptr<TcpPeer>> tcpPeers;


### PR DESCRIPTION
This PR fixes two things:
 
1. Fix handling socket peer close if not attached to peer anymore. The peer must not be affected by that event, and not be closed. Unexpected peer socket close happens if both ends try to connect at the same time.
2. epoll_wait() may wait forever if no socket is in its watchlist. This prevented RX and TX threads from termination during transport service stop. We introduce an evenfd which is in the watchlist of all TX and RX threads. Writing to that eventfd wakes up epoll_wait().
    
It also clarifies some LOG_DEBUG messages.
