### PR TITLE
TCP RPC: Fix: Avoid excessive RPC connections

### DIFF
--- a/src/libgeds/Server.cpp
+++ b/src/libgeds/Server.cpp
@@ -155,7 +155,7 @@ void Server::TcpListenThread() {
     }
     if (_geds->_tcpTransport->addEndpointPassive(newsock) == false) {
       ::close(newsock);
-      LOG_ERROR("Server: Adding new TCP client failed ");
+      LOG_DEBUG("Server: Adding new TCP client failed ");
     }
   }
   close(sock);

--- a/src/libgeds/TcpTransport.h
+++ b/src/libgeds/TcpTransport.h
@@ -182,8 +182,12 @@ public:
   sendRpcRequest(uint64_t dest, std::string name, size_t src_off, size_t len);
   int sendRpcReply(uint64_t reqId, int in_fd, uint64_t start, size_t len, int status);
   void addEndpoint(std::shared_ptr<TcpEndpoint> tep) {
-    auto lock = getWriteLock();
+    // Caller must hold TcpTransports write lock
     endpoints.emplace(tep->sock, tep);
+  };
+  void delEndpoint(std::shared_ptr<TcpEndpoint> tep) {
+    // Caller must hold TcpTransport write lock
+    endpoints.erase(tep->sock);
   };
   TcpPeer(std::string name, std::shared_ptr<GEDS> geds, TcpTransport &tcpTransport)
       : Id(SStringHash(name)), _geds(std::move(geds)), _tcpTransport(tcpTransport),


### PR DESCRIPTION
If two sides race in actively establishing connections to its peer side, excessive connections resulted, which are to be dropped.