### PR TITLE
Fix: File listing after update.

### DIFF
--- a/src/libgeds/GEDS.cpp
+++ b/src/libgeds/GEDS.cpp
@@ -659,7 +659,7 @@ absl::StatusOr<GEDSFileStatus> GEDS::status(const std::string &bucket, const std
   }
 
   // Location is most likely a file.
-  auto obj = _metadataService.lookup(bucket, key);
+  auto obj = _metadataService.lookup(bucket, key, true /* invalidate */);
   if (obj.ok()) {
     return GEDSFileStatus{.key = key, .size = obj->info.size, .isDirectory = false};
   }

--- a/src/libgeds/MetadataService.cpp
+++ b/src/libgeds/MetadataService.cpp
@@ -249,6 +249,8 @@ absl::Status MetadataService::createObject(const geds::Object &obj) {
 absl::Status MetadataService::updateObject(const geds::Object &obj) {
   METADATASERVICE_CHECK_CONNECTED;
 
+  (void)_mdsCache.updateObject(obj);
+
   geds::rpc::Object request;
   auto id = request.mutable_id();
   id->set_bucket(obj.id.bucket);


### PR DESCRIPTION
Issue: Updates to files were not stored in the GEDS internal cache. This resulted in invalid file listings.

To mitigate this issue the following changes were added:
- Updates are now reflected in the cache.
- The metadata server is always queried when the file status is requested.