### PR TITLE
Python: Improve integration with smart_open

### DIFF
--- a/.travis/build-geds.sh
+++ b/.travis/build-geds.sh
@@ -49,7 +49,7 @@ if [ "${TRAVIS:-""}" == "true" ]; then
         -e BUILD_TARGET=${DOCKER_BUILD_TARGET} \
         -e BUILD_TYPE=${CMAKE_BUILD_TYPE} \
         -e GEDS_VERSION=${GEDS_VERSION} \
-        -e GEDS_INSTALL_PREFIX="/install/" \
+        -e GEDS_INSTALL_PREFIX="/install/geds" \
         -e ARTIFACTS_PREFIX="/src/geds/travis_artifacts/" \
         -w "/build/geds" \
         -t docker.io/python:3.10-buster \

--- a/package_python.sh
+++ b/package_python.sh
@@ -24,12 +24,12 @@ BUILD_TARGET=$(echo ${BUILD_TARGET} | awk '{print tolower($0)}')
 BUILD_TYPE=$(echo ${BUILD_TYPE} | awk '{print tolower($0)}')
 
 ARTIFACTS_DIR="${ARTIFACTS_DIR:-"${ROOT}/travis_artifacts"}"
-GEDS_INSTALL_PREFIX=${GEDS_INSTALL_PREFIX:-"${ROOT}/travis_install"}
+GEDS_INSTALL_PREFIX=${GEDS_INSTALL_PREFIX:-"${ROOT}/travis_install/geds"}
 BUILD_LOC=$(mktemp -d /tmp/gedspy_XXX)
 
 cp -a src/python/geds_smart_open/ "${BUILD_LOC}/"
 cd "${BUILD_LOC}/geds_smart_open"
-cp "${GEDS_INSTALL_PREFIX}/geds/python/pygeds.so" src/geds_smart_open/
+cp "${GEDS_INSTALL_PREFIX}/python/pygeds.so" src/geds_smart_open/
 sed -i "s/SNAPSHOT/${GEDS_VERSION}/g" "pyproject.toml"
 
 pip install 'build[virtualenv]'

--- a/src/python/geds_smart_open/src/geds_smart_open/__init__.py
+++ b/src/python/geds_smart_open/src/geds_smart_open/__init__.py
@@ -8,7 +8,8 @@ from smart_open.transport import register_transport
 
 from . import geds
 from .geds import register_object_store
+from .geds import relocate
 
 register_transport(geds)
 
-__all__ = ["GEDS", "register_object_store"]
+__all__ = ["GEDS", "register_object_store", "relocate"]

--- a/src/python/geds_smart_open/src/geds_smart_open/geds.py
+++ b/src/python/geds_smart_open/src/geds_smart_open/geds.py
@@ -233,6 +233,12 @@ class GEDSInstance(object):
             if GEDS_AVAILABLE_MEMORY is not None:
                 config.available_local_memory = int(GEDS_AVAILABLE_MEMORY)
 
+            GEDS_RELOCATE_WHEN_STOPPING = os.environ.get("GEDS_RELOCATE_WHEN_STOPPING")
+            if GEDS_RELOCATE_WHEN_STOPPING is not None:
+                config.force_relocation_when_stopping = (
+                    GEDS_RELOCATE_WHEN_STOPPING.lower() in ("true", "1", "t")
+                )
+
             # Init GEDS
             cls._geds = pygeds.GEDS(config)
             try:

--- a/src/python/geds_smart_open/src/geds_smart_open/geds.py
+++ b/src/python/geds_smart_open/src/geds_smart_open/geds.py
@@ -225,8 +225,15 @@ class GEDSInstance(object):
             if BLOCK_SIZE is not None:
                 config.cache_block_size = int(BLOCK_SIZE)
 
-            # Init GEDS
+            GEDS_AVAILABLE_STORAGE = os.environ.get("GEDS_AVAILABLE_STORAGE")
+            if GEDS_AVAILABLE_STORAGE is not None:
+                config.available_local_storage = int(GEDS_AVAILABLE_STORAGE)
 
+            GEDS_AVAILABLE_MEMORY = os.environ.get("GEDS_AVAILABLE_MEMORY")
+            if GEDS_AVAILABLE_MEMORY is not None:
+                config.available_local_memory = int(GEDS_AVAILABLE_MEMORY)
+
+            # Init GEDS
             cls._geds = pygeds.GEDS(config)
             try:
                 cls._geds.start()
@@ -266,9 +273,11 @@ class GEDSInstance(object):
     def object_store_mapped(cls, bucket: str) -> bool:
         return bucket in cls._known_s3_buckets
 
+
 @atexit.register
 def handle_shutdown():
     GEDSInstance.handle_shutdown()
+
 
 def register_object_store(
     bucket: str, endpoint_url: str, access_key: str, secret_key: str

--- a/src/python/wrapper.cpp
+++ b/src/python/wrapper.cpp
@@ -44,7 +44,8 @@ PYBIND11_MODULE(pygeds, m) {
       .def_readwrite("port", &GEDSConfig::port)
       .def_readwrite("port_http_server", &GEDSConfig::portHttpServer)
       .def_readwrite("local_storage_path", &GEDSConfig::localStoragePath)
-      .def_readwrite("cache_block_size", &GEDSConfig::cacheBlockSize);
+      .def_readwrite("cache_block_size", &GEDSConfig::cacheBlockSize)
+      .def_readwrite("cache_objects_from_s3", &GEDSConfig::cache_objects_from_s3);
 
   py::class_<GEDS, std::shared_ptr<GEDS>>(m, "GEDS")
       .def_property_readonly_static(

--- a/src/python/wrapper.cpp
+++ b/src/python/wrapper.cpp
@@ -45,7 +45,9 @@ PYBIND11_MODULE(pygeds, m) {
       .def_readwrite("port_http_server", &GEDSConfig::portHttpServer)
       .def_readwrite("local_storage_path", &GEDSConfig::localStoragePath)
       .def_readwrite("cache_block_size", &GEDSConfig::cacheBlockSize)
-      .def_readwrite("cache_objects_from_s3", &GEDSConfig::cache_objects_from_s3);
+      .def_readwrite("cache_objects_from_s3", &GEDSConfig::cache_objects_from_s3)
+      .def_readwrite("available_local_storage", &GEDSConfig::available_local_storage)
+      .def_readwrite("available_local_memory", &GEDSConfig::available_local_memory);
 
   py::class_<GEDS, std::shared_ptr<GEDS>>(m, "GEDS")
       .def_property_readonly_static(

--- a/src/python/wrapper.cpp
+++ b/src/python/wrapper.cpp
@@ -47,7 +47,8 @@ PYBIND11_MODULE(pygeds, m) {
       .def_readwrite("cache_block_size", &GEDSConfig::cacheBlockSize)
       .def_readwrite("cache_objects_from_s3", &GEDSConfig::cache_objects_from_s3)
       .def_readwrite("available_local_storage", &GEDSConfig::available_local_storage)
-      .def_readwrite("available_local_memory", &GEDSConfig::available_local_memory);
+      .def_readwrite("available_local_memory", &GEDSConfig::available_local_memory)
+      .def_readwrite("force_relocation_when_stopping", &GEDSConfig::force_relocation_when_stopping);
 
   py::class_<GEDS, std::shared_ptr<GEDS>>(m, "GEDS")
       .def_property_readonly_static(


### PR DESCRIPTION
The GEDS `smart_open` integration has been extended so that additional GEDS configuration options are supported:
- `GEDS_AVAILABLE_STORAGE`: Configure the storage threshold for GEDS.
- `GEDS_AVAILABLE_MEMORY`: Configure the memory threshold for GEDS.
- `GEDS_RELOCATE_WHEN_STOPPING`: Relocate files in GEDS to a configured object store when GEDS ist stopped.

Changes to the smart open integration:
- GEDS is now stopped when the application exists.
- `relocation` is exposed as an API.
- `open(file, mode='wb')` now always creates a new file in `GEDS`
- `open(file, mode='ab')` does an explicit copy of the file if the file is not writable (e.g. on a remote node).
- The Python API has now been improved so that GEDS read calls directly allocate a writable Python buffer.