### PR TITLE
IO Benchmark: Make the benchmark more consistent.

### DIFF
--- a/src/python/serve_benchmark.py
+++ b/src/python/serve_benchmark.py
@@ -10,11 +10,17 @@ from time import sleep
 from pygeds import status, GEDS, GEDSConfig
 
 METADATA_SERVER = os.environ.get("GEDS_METADATASERVER", "zac13:4381")
+GEDS_TMP = os.environ.get("GEDS_TMP")
 BUCKET_NAME = os.environ.get("BUCKET_NAME", "benchmark")
 MAX_THREADS = int(os.environ.get("MAX_THREADS", "16"))
 MAX_SIZE = int(os.environ.get("MAX_SIZE", "18"))
 
-instance = GEDS(GEDSConfig(METADATA_SERVER))
+config = GEDSConfig(METADATA_SERVER)
+config.available_local_storage = 1000 * 1024 * 1024 * 1024
+TMP_FOLDER = os.environ.get("GEDS_TMP")
+if TMP_FOLDER is not None:
+    config.local_storage_path = TMP_FOLDER
+instance = GEDS(config)
 try:
     instance.start()
 except status.StatusNotOk as e:
@@ -29,26 +35,26 @@ except status.StatusNotOk as e:
 MAX_BUFFERSIZE = 2097152
 FACTOR_SIZE = 1024
 for i in range(0, MAX_SIZE + 1):
-    print(f"Create factor: {i}")
-    files = [
-        instance.create(BUCKET_NAME, f"{i}-{j}.data") for j in range(0, MAX_THREADS)
-    ]
-    factor = 2**i
-    target_size = factor * FACTOR_SIZE
-    position = 0
-    while position < target_size:
-        buffer = np.random.randint(0, high=255, size=MAX_BUFFERSIZE, dtype=np.uint8)
-        s = target_size - position
-        if s > MAX_BUFFERSIZE:
-            for file in files:
-                file.write(buffer, position, MAX_BUFFERSIZE)
-            position += MAX_BUFFERSIZE
-        else:
-            for file in files:
-                file.write(buffer, position, MAX_BUFFERSIZE)
-            position += s
-    for file in files:
-        file.seal()
+    for t in range(1, MAX_THREADS + 1):
+        factor = 2**i
+        target_size = factor * FACTOR_SIZE
+
+        print(f"Create factor: {i} with size {target_size}")
+        files = [instance.create(BUCKET_NAME, f"{t}-{i}-{j}.data") for j in range(0, t)]
+        position = 0
+        while position < target_size:
+            buffer = np.random.randint(0, high=255, size=MAX_BUFFERSIZE, dtype=np.uint8)
+            s = target_size - position
+            if s > MAX_BUFFERSIZE:
+                for file in files:
+                    file.write(buffer, position, MAX_BUFFERSIZE)
+                position += MAX_BUFFERSIZE
+            else:
+                for file in files:
+                    file.write(buffer, position, MAX_BUFFERSIZE)
+                position += s
+        for file in files:
+            file.seal()
 print(
     f"Created all benchmark files with max size {MAX_SIZE} for {MAX_THREADS} threads. Waiting."
 )


### PR DESCRIPTION
- Create a separate file for each download.
- Add flag to do cached reads.
- Open a separate file for each size/thread combination.
- Fix off-by-one when computing the number of threads.
